### PR TITLE
Startup problems fix

### DIFF
--- a/recipes/_properties.rb
+++ b/recipes/_properties.rb
@@ -15,12 +15,3 @@ template "/etc/kafka/server.properties" do
     variables({:properties => node["confluent"]["kafka"]["server.properties"]})
     notifies :restart, "service[kafka]"
 end
-
-template "/etc/kafka/schema-registry.properties" do
-    source "properties.erb"
-    owner 'confluent'
-    group 'confluent'
-    mode '644'
-    variables({:properties => node["confluent"]["kafka"]["schema-registry.properties"]})
-    notifies :restart, "service[schema-registry]"
-end

--- a/recipes/_services.rb
+++ b/recipes/_services.rb
@@ -34,5 +34,5 @@ end
 
 service "zookeeper" do
     supports :restart => true, :status => true
-    action [:enable, :start]
+    action :enable
 end

--- a/recipes/schema-registry.rb
+++ b/recipes/schema-registry.rb
@@ -12,6 +12,14 @@ template "/etc/init.d/schema-registry" do
     notifies :restart, "service[schema-registry]"
 end
 
+template "/etc/kafka/schema-registry.properties" do
+    source "properties.erb"
+    owner 'confluent'
+    group 'confluent'
+    mode '644'
+    variables({:properties => node["confluent"]["kafka"]["schema-registry.properties"]})
+    notifies :restart, "service[schema-registry]"
+end
 
 service "schema-registry" do
     supports :restart => true, :status => true

--- a/templates/default/service.erb
+++ b/templates/default/service.erb
@@ -20,7 +20,7 @@ start(){
 
     if [ $pid ] ; then
         echo "<%= @name %> already running: $pid"
-        exit 1
+        return 1
     fi
 
     echo -n "Starting <%= @name %>:"
@@ -33,7 +33,7 @@ stop(){
 
     if ! [ $pid ] ; then
         echo "<%= @name %> already stopped"
-        exit 1
+        return 1
     fi
 
     echo -n "Stopping <%= @name %>:"
@@ -45,10 +45,10 @@ status(){
     pid=`pid`
     if [ "$pid" = "" ] ; then
         echo "Stopped"
-        exit 3
+        return 3
     else
         echo "Running $pid"
-        exit 0
+        return 0
     fi
 }
 


### PR DESCRIPTION
Two small fixes:
- service scripts exited instead of returning their values, leading to an error at first startup, when restart encountered a not running service and exited instead of starting it
- wasn't able to install just Kafka, because `recipies/_properties.rb` referenced resources that were only available when schema registry was installed, too.
