### PR TITLE
Changes for confluent platform 3.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,7 @@ Added Schema-Registry service and configuration.
 # 0.3.0
 
 Added Kafka REST service and configuration.
+
+# 0.5.0
+
+Updated for Confluent platform 3.0.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,5 +1,5 @@
-default["confluent"]["version"] = "2.0"
-default["confluent"]["scala_version"] = "2.11.7"
+default["confluent"]["version"] = "3.0"
+default["confluent"]["scala_version"] = "2.11"
 
 # Confluent repository defaults
 default["confluent"]["repository"]["rpm"]["url"] = "http://packages.confluent.io/rpm/#{node["confluent"]["version"]}"

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'lars@mobilecologne.de'
 license          'Apache License Version 2.0'
 description      'Installs/Configures confluent.io platform from rpm/deb packages'
 long_description 'Installs/Configures confluent.io platform from rpm/deb packages'
-version          '0.4.0'
+version          '0.5.0'
 
 depends 'java'
 depends 'apt'

--- a/recipes/_repositories.rb
+++ b/recipes/_repositories.rb
@@ -9,6 +9,13 @@ when 'rhel'
         gpgkey node.attribute['confluent']['repository']['rpm']['key']
         action :create
     end
+    yum_repository 'confluent_dist' do
+        description "Repository for #{version} of Confluent (dist) packages"
+        baseurl "#{node.attribute['confluent']['repository']['rpm']['url']}/#{node['platform_version'].to_i}"
+        gpgkey node.attribute['confluent']['repository']['rpm']['key']
+        action :create
+    end
+    
 
 when 'debian'
     apt_repository 'confluent' do

--- a/recipes/_repositories.rb
+++ b/recipes/_repositories.rb
@@ -9,13 +9,14 @@ when 'rhel'
         gpgkey node.attribute['confluent']['repository']['rpm']['key']
         action :create
     end
-    yum_repository 'confluent_dist' do
-        description "Repository for #{version} of Confluent (dist) packages"
-        baseurl "#{node.attribute['confluent']['repository']['rpm']['url']}/#{node['platform_version'].to_i}"
-        gpgkey node.attribute['confluent']['repository']['rpm']['key']
-        action :create
+    if version >= '3.0'
+        yum_repository 'confluent_dist' do
+            description "Repository for #{version} of Confluent (dist) packages"
+            baseurl "#{node.attribute['confluent']['repository']['rpm']['url']}/#{node['platform_version'].to_i}"
+            gpgkey node.attribute['confluent']['repository']['rpm']['key']
+            action :create
+        end
     end
-    
 
 when 'debian'
     apt_repository 'confluent' do


### PR DESCRIPTION
Using confluent platform 3.0 requires one to add another RPM repo.